### PR TITLE
Add tools playbook and roles to install third-party tools and clone projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ ansible-playbook create-wireguard.yml -i inventories/production/hosts
 
 ansible-playbook ubuntu-servers.yml -i inventories/production/hosts
 
+ansible-playbook tools.yml -i inventories/localhost/hosts
+
 ansible-playbook create-wireguard-peer.yml -i inventories/production/hosts
 
 ssh -i .keys/*_id_rsa 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ansible-playbook create-wireguard.yml -i inventories/production/hosts
 
 ansible-playbook ubuntu-servers.yml -i inventories/production/hosts
 
-ansible-playbook tools.yml -i inventories/localhost/hosts
+ansible-playbook tools.yml -i inventories/production-unsecure/hosts
 
 ansible-playbook create-wireguard-peer.yml -i inventories/production/hosts
 

--- a/roles/custom-projects/defaults/main.yml
+++ b/roles/custom-projects/defaults/main.yml
@@ -2,8 +2,8 @@
 custom_projects:
   - name: jfr-merger
     repo: https://github.com/izual0110/jfr-merger.git
-    version: main
+    version: master
 
   - name: RootCauseLab
     repo: https://github.com/izual0110/RootCauseLab.git
-    version: main
+    version: master

--- a/roles/custom-projects/defaults/main.yml
+++ b/roles/custom-projects/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+custom_projects:
+  - name: jfr-merger
+    repo: https://github.com/izual0110/jfr-merger.git
+    version: main
+
+  - name: RootCauseLab
+    repo: https://github.com/izual0110/RootCauseLab.git
+    version: main

--- a/roles/custom-projects/tasks/main.yml
+++ b/roles/custom-projects/tasks/main.yml
@@ -5,14 +5,10 @@
     state: directory
     mode: "0755"
 
-- name: Clone my projects
+- name: Clone custom projects
   git:
     repo: "{{ item.repo }}"
     dest: "{{ ansible_env.HOME }}/tools/{{ item.name }}"
-    version: main
+    version: "{{ item.version | default('main') }}"
     update: true
-  loop:
-    - name: jfr-merger
-      repo: https://github.com/izual0110/jfr-merger.git
-    - name: RootCauseLab
-      repo: https://github.com/izual0110/RootCauseLab.git
+  loop: "{{ custom_projects }}"

--- a/roles/custom-projects/tasks/main.yml
+++ b/roles/custom-projects/tasks/main.yml
@@ -9,6 +9,6 @@
   git:
     repo: "{{ item.repo }}"
     dest: "{{ ansible_env.HOME }}/tools/{{ item.name }}"
-    version: "{{ item.version | default('main') }}"
+    version: "{{ item.version | default('master') }}"
     update: true
   loop: "{{ custom_projects }}"

--- a/roles/custom-projects/tasks/main.yml
+++ b/roles/custom-projects/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Ensure tools directory exists
+  file:
+    path: "{{ ansible_env.HOME }}/tools"
+    state: directory
+    mode: "0755"
+
+- name: Clone my projects
+  git:
+    repo: "{{ item.repo }}"
+    dest: "{{ ansible_env.HOME }}/tools/{{ item.name }}"
+    version: main
+    update: true
+  loop:
+    - name: jfr-merger
+      repo: https://github.com/izual0110/jfr-merger.git
+    - name: RootCauseLab
+      repo: https://github.com/izual0110/RootCauseLab.git

--- a/roles/third-party-tools/defaults/main.yml
+++ b/roles/third-party-tools/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+third_party_tools:
+  - name: jol
+    version: "0.17"
+    archive_url: "https://github.com/openjdk/jol/archive/refs/tags/0.17.tar.gz"
+    archive_name: "jol-0.17.tar.gz"
+    extract_to: "{{ ansible_env.HOME }}/tools"
+
+  - name: async-profiler
+    version: "4.3"
+    archive_url: "https://github.com/async-profiler/async-profiler/releases/download/v4.3/async-profiler-4.3-linux-x64.tar.gz"
+    archive_name: "async-profiler-4.3-linux-x64.tar.gz"
+    extract_to: "{{ ansible_env.HOME }}/tools"
+
+  - name: eclipse-mat
+    version: "1.16.1"
+    archive_url: "https://archive.eclipse.org/mat/1.16.1/rcp/MemoryAnalyzer-1.16.1.202505251011-linux.gtk.x86_64.zip"
+    archive_name: "MemoryAnalyzer-1.16.1-linux.gtk.x86_64.zip"
+    extract_to: "{{ ansible_env.HOME }}/tools/eclipse-mat-1.16.1"
+
+  - name: jmc
+    version: "9.1.1"
+    archive_url: "https://github.com/openjdk/jmc/releases/download/9.1.1/jmc-9.1.1-linux.gtk.x86_64.tar.gz"
+    archive_name: "jmc-9.1.1-linux.gtk.x86_64.tar.gz"
+    extract_to: "{{ ansible_env.HOME }}/tools"
+
+  - name: visualvm
+    version: "2.2.1"
+    archive_url: "https://github.com/oracle/visualvm/releases/download/2.2.1/visualvm_221.zip"
+    archive_name: "visualvm_221.zip"
+    extract_to: "{{ ansible_env.HOME }}/tools"

--- a/roles/third-party-tools/defaults/main.yml
+++ b/roles/third-party-tools/defaults/main.yml
@@ -17,14 +17,14 @@ third_party_tools:
 
   - name: eclipse-mat
     version: "1.16.1"
-    archive_url: "https://archive.eclipse.org/mat/1.16.1/rcp/MemoryAnalyzer-1.16.1.202505251011-linux.gtk.x86_64.zip"
+    archive_url: "https://mirror.kakao.com/eclipse/mat/1.16.1/rcp/MemoryAnalyzer-1.16.1.20250109-linux.gtk.x86_64.zip"
     archive_name: "MemoryAnalyzer-1.16.1-linux.gtk.x86_64.zip"
     extract_to: "{{ third_party_tools_dir }}/eclipse-mat-1.16.1"
 
   - name: jmc
     version: "9.1.1"
-    archive_url: "https://github.com/openjdk/jmc/releases/download/9.1.1/jmc-9.1.1-linux.gtk.x86_64.tar.gz"
-    archive_name: "jmc-9.1.1-linux.gtk.x86_64.tar.gz"
+    archive_url: "https://cdn.azul.com/zmc/bin/zmc9.1.1.1.41-ca-linux_x64.tar.gz"
+    archive_name: "zmc9.1.1.1.41-ca-linux_x64.tar.gz"
     extract_to: "{{ third_party_tools_dir }}"
 
   - name: visualvm

--- a/roles/third-party-tools/defaults/main.yml
+++ b/roles/third-party-tools/defaults/main.yml
@@ -1,31 +1,34 @@
 ---
+third_party_tools_dir: "{{ ansible_env.HOME }}/tools"
+third_party_downloads_dir: "{{ third_party_tools_dir }}/.downloads"
+
 third_party_tools:
   - name: jol
     version: "0.17"
     archive_url: "https://github.com/openjdk/jol/archive/refs/tags/0.17.tar.gz"
     archive_name: "jol-0.17.tar.gz"
-    extract_to: "{{ ansible_env.HOME }}/tools"
+    extract_to: "{{ third_party_tools_dir }}"
 
   - name: async-profiler
     version: "4.3"
     archive_url: "https://github.com/async-profiler/async-profiler/releases/download/v4.3/async-profiler-4.3-linux-x64.tar.gz"
     archive_name: "async-profiler-4.3-linux-x64.tar.gz"
-    extract_to: "{{ ansible_env.HOME }}/tools"
+    extract_to: "{{ third_party_tools_dir }}"
 
   - name: eclipse-mat
     version: "1.16.1"
     archive_url: "https://archive.eclipse.org/mat/1.16.1/rcp/MemoryAnalyzer-1.16.1.202505251011-linux.gtk.x86_64.zip"
     archive_name: "MemoryAnalyzer-1.16.1-linux.gtk.x86_64.zip"
-    extract_to: "{{ ansible_env.HOME }}/tools/eclipse-mat-1.16.1"
+    extract_to: "{{ third_party_tools_dir }}/eclipse-mat-1.16.1"
 
   - name: jmc
     version: "9.1.1"
     archive_url: "https://github.com/openjdk/jmc/releases/download/9.1.1/jmc-9.1.1-linux.gtk.x86_64.tar.gz"
     archive_name: "jmc-9.1.1-linux.gtk.x86_64.tar.gz"
-    extract_to: "{{ ansible_env.HOME }}/tools"
+    extract_to: "{{ third_party_tools_dir }}"
 
   - name: visualvm
     version: "2.2.1"
     archive_url: "https://github.com/oracle/visualvm/releases/download/2.2.1/visualvm_221.zip"
     archive_name: "visualvm_221.zip"
-    extract_to: "{{ ansible_env.HOME }}/tools"
+    extract_to: "{{ third_party_tools_dir }}"

--- a/roles/third-party-tools/tasks/main.yml
+++ b/roles/third-party-tools/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: Ensure tools directory exists
   file:
-    path: "{{ ansible_env.HOME }}/tools"
+    path: "{{ third_party_tools_dir }}"
     state: directory
     mode: "0755"
 
 - name: Ensure tools tmp directory exists
   file:
-    path: "{{ ansible_env.HOME }}/tools/.downloads"
+    path: "{{ third_party_downloads_dir }}"
     state: directory
     mode: "0755"
 
@@ -21,13 +21,21 @@
 - name: Download third-party archives
   get_url:
     url: "{{ item.archive_url }}"
-    dest: "{{ ansible_env.HOME }}/tools/.downloads/{{ item.archive_name }}"
+    dest: "{{ third_party_downloads_dir }}/{{ item.archive_name }}"
     mode: "0644"
   loop: "{{ third_party_tools }}"
 
 - name: Unpack third-party archives
   unarchive:
-    src: "{{ ansible_env.HOME }}/tools/.downloads/{{ item.archive_name }}"
+    src: "{{ third_party_downloads_dir }}/{{ item.archive_name }}"
     dest: "{{ item.extract_to }}"
     remote_src: true
+    creates: "{{ item.extract_to }}/.installed-{{ item.name }}-{{ item.version }}"
+  loop: "{{ third_party_tools }}"
+
+- name: Create install marker files
+  file:
+    path: "{{ item.extract_to }}/.installed-{{ item.name }}-{{ item.version }}"
+    state: touch
+    mode: "0644"
   loop: "{{ third_party_tools }}"

--- a/roles/third-party-tools/tasks/main.yml
+++ b/roles/third-party-tools/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Ensure tools directory exists
+  file:
+    path: "{{ ansible_env.HOME }}/tools"
+    state: directory
+    mode: "0755"
+
+- name: Ensure tools tmp directory exists
+  file:
+    path: "{{ ansible_env.HOME }}/tools/.downloads"
+    state: directory
+    mode: "0755"
+
+- name: Ensure extraction directories exist
+  file:
+    path: "{{ item.extract_to }}"
+    state: directory
+    mode: "0755"
+  loop: "{{ third_party_tools }}"
+
+- name: Download third-party archives
+  get_url:
+    url: "{{ item.archive_url }}"
+    dest: "{{ ansible_env.HOME }}/tools/.downloads/{{ item.archive_name }}"
+    mode: "0644"
+  loop: "{{ third_party_tools }}"
+
+- name: Unpack third-party archives
+  unarchive:
+    src: "{{ ansible_env.HOME }}/tools/.downloads/{{ item.archive_name }}"
+    dest: "{{ item.extract_to }}"
+    remote_src: true
+  loop: "{{ third_party_tools }}"

--- a/tools.yml
+++ b/tools.yml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: true
+  roles:
+    - custom-projects
+    - third-party-tools


### PR DESCRIPTION
### Motivation

- Provide a simple local playbook to populate `~/tools` with frequently used third-party tooling and personal projects for developer workstations.
- Centralize third-party tool metadata (URLs, versions, and extract destinations) so they can be downloaded and unpacked reproducibly by Ansible.

### Description

- Added `tools.yml` playbook to run two new roles (`custom-projects` and `third-party-tools`) on `localhost` with `connection: local`.
- Added `roles/custom-projects/tasks/main.yml` to ensure `{{ ansible_env.HOME }}/tools` exists and to clone two repositories into that directory (`jfr-merger` and `RootCauseLab`).
- Added `roles/third-party-tools/defaults/main.yml` to declare a `third_party_tools` list containing metadata for `jol`, `async-profiler`, `eclipse-mat`, `jmc`, and `visualvm` including `archive_url`, `archive_name`, `version`, and `extract_to` paths.
- Added `roles/third-party-tools/tasks/main.yml` to create `~/tools` and `~/tools/.downloads`, ensure extraction directories exist, download archives to `~/tools/.downloads`, and unpack them to each tool's `extract_to` location.
- Updated `README.md` to include the new `ansible-playbook tools.yml -i inventories/localhost/hosts` instruction.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad9d4190588327a455d4b473192ca5)