### PR TITLE
Add macOS support for third-party tools role

### DIFF
--- a/roles/third-party-tools/defaults/main.yml
+++ b/roles/third-party-tools/defaults/main.yml
@@ -2,7 +2,14 @@
 third_party_tools_dir: "{{ ansible_env.HOME }}/tools"
 third_party_downloads_dir: "{{ third_party_tools_dir }}/.downloads"
 
-third_party_tools:
+third_party_macos_arch: >-
+  {{
+    'x64' if ansible_architecture in ['x86_64', 'amd64']
+    else 'arm64' if ansible_architecture in ['arm64', 'aarch64']
+    else ansible_architecture
+  }}
+
+third_party_tools_linux:
   - name: jol
     version: "0.17"
     archive_url: "https://github.com/openjdk/jol/archive/refs/tags/0.17.tar.gz"
@@ -32,3 +39,24 @@ third_party_tools:
     archive_url: "https://github.com/oracle/visualvm/releases/download/2.2.1/visualvm_221.zip"
     archive_name: "visualvm_221.zip"
     extract_to: "{{ third_party_tools_dir }}"
+
+third_party_tools_macos:
+  - name: jol
+    version: "0.17"
+    archive_url: "https://github.com/openjdk/jol/archive/refs/tags/0.17.tar.gz"
+    archive_name: "jol-0.17.tar.gz"
+    extract_to: "{{ third_party_tools_dir }}"
+
+  - name: async-profiler
+    version: "4.3"
+    archive_url: "https://github.com/async-profiler/async-profiler/releases/download/v4.3/async-profiler-4.3-macos-{{ third_party_macos_arch }}.tar.gz"
+    archive_name: "async-profiler-4.3-macos-{{ third_party_macos_arch }}.tar.gz"
+    extract_to: "{{ third_party_tools_dir }}"
+
+  - name: visualvm
+    version: "2.2.1"
+    archive_url: "https://github.com/oracle/visualvm/releases/download/2.2.1/visualvm_221.zip"
+    archive_name: "visualvm_221.zip"
+    extract_to: "{{ third_party_tools_dir }}"
+
+third_party_tools: "{{ third_party_tools_linux if ansible_system == 'Linux' else third_party_tools_macos if ansible_system == 'Darwin' else [] }}"


### PR DESCRIPTION
### Motivation
- Enable running the `tools.yml` playbook on macOS hosts by providing macOS-specific tool definitions and architecture-aware asset selection. 
- Ensure `async-profiler` and other tools download the correct macOS binary for the host CPU (`x64` vs `arm64`).

### Description
- Added a new variable `third_party_macos_arch` that maps `ansible_architecture` to `x64` or `arm64` for macOS asset names. 
- Split the tool definitions into platform-specific lists: `third_party_tools_linux` and `third_party_tools_macos` in `roles/third-party-tools/defaults/main.yml`. 
- Made `third_party_tools` dynamically select the proper list based on `ansible_system` (`Linux` or `Darwin`).
- Updated macOS `async-profiler` `archive_url`/`archive_name` to use the `third_party_macos_arch` template so the correct macOS archive is downloaded.

### Testing
- Ran `ansible-playbook --syntax-check tools.yml`, which failed in the environment because `ansible-playbook` is not available (command not found).
- Validated YAML parsing of the modified defaults file with `ruby -e "require 'yaml'; YAML.load_file('roles/third-party-tools/defaults/main.yml')"`, which succeeded. 
- Attempted YAML load with Python (`python -c` script), which failed due to missing `yaml` Python module in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adce7f8e08832797dc09c68cfeebd9)