### PR TITLE
Add GCLogAnalyzer to third-party tools role

### DIFF
--- a/roles/third-party-tools/defaults/main.yml
+++ b/roles/third-party-tools/defaults/main.yml
@@ -34,6 +34,12 @@ third_party_tools_linux:
     archive_name: "zmc9.1.1.1.41-ca-linux_x64.tar.gz"
     extract_to: "{{ third_party_tools_dir }}"
 
+  - name: gcloganalyzer
+    version: "26.02.0"
+    archive_url: "https://cdn.azul.com/gcla/26.02.0/GCLogAnalyzer-26.02.0-ca.zip"
+    archive_name: "GCLogAnalyzer-26.02.0-ca.zip"
+    extract_to: "{{ third_party_tools_dir }}"
+
   - name: visualvm
     version: "2.2.1"
     archive_url: "https://github.com/oracle/visualvm/releases/download/2.2.1/visualvm_221.zip"
@@ -57,6 +63,12 @@ third_party_tools_macos:
     version: "2.2.1"
     archive_url: "https://github.com/oracle/visualvm/releases/download/2.2.1/visualvm_221.zip"
     archive_name: "visualvm_221.zip"
+    extract_to: "{{ third_party_tools_dir }}"
+
+  - name: gcloganalyzer
+    version: "26.02.0"
+    archive_url: "https://cdn.azul.com/gcla/26.02.0/GCLogAnalyzer-26.02.0-ca.zip"
+    archive_name: "GCLogAnalyzer-26.02.0-ca.zip"
     extract_to: "{{ third_party_tools_dir }}"
 
 third_party_tools: "{{ third_party_tools_linux if ansible_system == 'Linux' else third_party_tools_macos if ansible_system == 'Darwin' else [] }}"


### PR DESCRIPTION
### Motivation
- Add GCLogAnalyzer (26.02.0) to the third-party tools catalog so the role can download and install it on Linux and macOS.

### Description
- Added `gcloganalyzer` entries (version `26.02.0`) to `third_party_tools_linux` and `third_party_tools_macos` in `roles/third-party-tools/defaults/main.yml` with `archive_url` `https://cdn.azul.com/gcla/26.02.0/GCLogAnalyzer-26.02.0-ca.zip`, `archive_name` `GCLogAnalyzer-26.02.0-ca.zip`, and `extract_to` set to `{{ third_party_tools_dir }}`.

### Testing
- Ran `ansible-playbook --syntax-check tools.yml` which could not be executed in this environment because `ansible-playbook` is not installed (command failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adecef29b08327840eef2bc099621a)